### PR TITLE
Make the webhook more resilient

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,6 +35,7 @@ patchesStrategicMerge:
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
 - webhookcainjection_patch.yaml
+- webhook_selector_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/default/webhook_selector_patch.yaml
+++ b/config/default/webhook_selector_patch.yaml
@@ -1,0 +1,17 @@
+#apiVersion: admissionregistration.k8s.io/v1
+#kind: MutatingWebhookConfiguration
+#metadata:
+#  name: mutating-webhook-configuration
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+  - name: vdeployment.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: Exists
+        - key: app.kubernetes.io/version
+          operator: Exists

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -18,6 +18,9 @@ images:
   - name: controller
     newName: "{{ .Values.registry.domain }}/{{ .Values.image.name }}"
     newTag: "{{ .Values.image.tag }}"
+replicas:
+  - name: controller-manager
+    count: 3
 
 resources:
   - ../default

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -342,7 +342,7 @@ metadata:
   name: '{{- .Release.Name | replace "." "-" | trunc 33 | trimSuffix "-" -}}-controller-manager'
   namespace: '{{ .Release.Namespace }}'
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.giantswarm.io/branch: '{{ .Values.project.branch }}'

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -492,6 +492,12 @@ webhooks:
       path: /validate-apps-v1-deployment
   failurePolicy: Fail
   name: vdeployment.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: Exists
+    - key: app.kubernetes.io/version
+      operator: Exists
   rules:
   - apiGroups:
     - apps


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14270

- Set the replicas number to 3 to avoid downtime during upgrades
- Add selector to affect only relevant deployments