### PR TITLE
Check K8s API connection as part of liveness probe

### DIFF
--- a/config/helm/manager_patch.yaml
+++ b/config/helm/manager_patch.yaml
@@ -13,3 +13,6 @@ spec:
             name: controller-manager
         - secretRef:
             name: controller-manager
+        livenessProbe:
+          periodSeconds: 30
+          timeoutSeconds: 10

--- a/controllers/health_probe.go
+++ b/controllers/health_probe.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/giantswarm/microerror"
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,12 +17,16 @@ type HealthProbe struct {
 }
 
 func (v *HealthProbe) HealthzCheck(_ *http.Request) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	// Check whether manager's client is able to communicate with Kubernetes API.
 	kubeSystemDeployments := appsv1.DeploymentList{}
-	err := v.List(context.Background(), &kubeSystemDeployments, &client.ListOptions{
+	err := v.List(ctx, &kubeSystemDeployments, &client.ListOptions{
 		Namespace: "kube-system",
 		Limit:     1,
 	})
+
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/controllers/health_probe.go
+++ b/controllers/health_probe.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+type HealthProbe struct {
+	client.Client
+}
+
+func (v *HealthProbe) HealthzCheck(_ *http.Request) error {
+	// Check whether manager's client is able to communicate with Kubernetes API.
+	kubeSystemDeployments := appsv1.DeploymentList{}
+	err := v.List(context.Background{}, &kubeSystemDeployments, &client.ListOptions{
+		Namespace: "kube-system",
+		Limit:     1,
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}

--- a/controllers/health_probe.go
+++ b/controllers/health_probe.go
@@ -18,7 +18,7 @@ type HealthProbe struct {
 func (v *HealthProbe) HealthzCheck(_ *http.Request) error {
 	// Check whether manager's client is able to communicate with Kubernetes API.
 	kubeSystemDeployments := appsv1.DeploymentList{}
-	err := v.List(context.Background{}, &kubeSystemDeployments, &client.ListOptions{
+	err := v.List(context.Background(), &kubeSystemDeployments, &client.ListOptions{
 		Namespace: "kube-system",
 		Limit:     1,
 	})

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,6 @@ require (
 
 replace (
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.24+incompatible
+	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -112,7 +112,7 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -258,9 +258,9 @@ data:
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
     kind: ControllerManagerConfig
     health:
-      healthProbeBindAddress: :8081
+      healthProbeBindAddress: '{{ .Values.healthProbeBindAddress }}'
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: '127.0.0.1:{{ .Values.metricsBindAddress }}'
     webhook:
       port: 9443
     leaderElection:

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -258,9 +258,9 @@ data:
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
     kind: ControllerManagerConfig
     health:
-      healthProbeBindAddress: '{{ .Values.healthProbeBindAddress }}'
+      healthProbeBindAddress: :8081
     metrics:
-      bindAddress: '127.0.0.1:{{ .Values.metricsBindAddress }}'
+      bindAddress: 127.0.0.1:8080
     webhook:
       port: 9443
     leaderElection:

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -382,6 +382,7 @@ spec:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 30
+          timeoutSeconds: 10
         name: manager
         ports:
         - containerPort: 9443

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -381,7 +381,7 @@ spec:
             path: /healthz
             port: 8081
           initialDelaySeconds: 15
-          periodSeconds: 20
+          periodSeconds: 30
         name: manager
         ports:
         - containerPort: 9443

--- a/main.go
+++ b/main.go
@@ -185,7 +185,11 @@ func mainE(ctx context.Context) error {
 
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	healthProbe := &controllers.HealthProbe{
+		Client: mgr.GetClient(),
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthProbe.HealthzCheck); err != nil {
 		return microerror.Mask(err)
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16697

Adds a custom `livenessProbe` at `/healthz`. It will try to list Deployments in `kube-system` namespace (limited to 1 to avoid long calls) to check if the K8s API is responsive.