### PR TITLE
Use v1alpha3 instead of v1alpha2 CAPI resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fetch CAPI `v1alpha3` `Cluster` resources, instead of `v1alpha2` for validating if an organization can be deleted or not.
+
 ## [0.4.0] - 2021-05-13
 
 ### Added

--- a/controllers/organization_validator.go
+++ b/controllers/organization_validator.go
@@ -80,8 +80,7 @@ func (v *OrganizationValidator) handle(ctx context.Context, req admission.Reques
 		})
 		if apimeta.IsNoMatchError(err) {
 			// If the CRD is not in place, just ignore the error.
-		}
-		if err != nil {
+		} else if err != nil {
 			return admission.Response{}, microerror.Mask(err)
 		}
 	}

--- a/controllers/organization_validator.go
+++ b/controllers/organization_validator.go
@@ -10,10 +10,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,19 +72,12 @@ func (v *OrganizationValidator) handle(ctx context.Context, req admission.Reques
 		}
 	}
 
-	orgClusters := &unstructured.UnstructuredList{}
-	orgClusters.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "cluster.x-k8s.io",
-		Version: "v1alpha2",
-		Kind:    "cluster",
-	})
+	orgClusters := capi.ClusterList{}
 	{
-		err := v.List(ctx, orgClusters, &client.ListOptions{
+		err := v.List(ctx, &orgClusters, &client.ListOptions{
 			LabelSelector: orgClustersSelector,
 		})
-		if apimeta.IsNoMatchError(err) {
-			// If the CRD is not in place, just ignore the error.
-		} else if err != nil {
+		if err != nil {
 			return admission.Response{}, microerror.Mask(err)
 		}
 	}

--- a/controllers/organization_validator.go
+++ b/controllers/organization_validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
@@ -77,6 +78,9 @@ func (v *OrganizationValidator) handle(ctx context.Context, req admission.Reques
 		err := v.List(ctx, &orgClusters, &client.ListOptions{
 			LabelSelector: orgClustersSelector,
 		})
+		if apimeta.IsNoMatchError(err) {
+			// If the CRD is not in place, just ignore the error.
+		}
 		if err != nil {
 			return admission.Response{}, microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18235

We are removing v1alpha2. Now v1alpha3 should be present on all installations.