### PR TITLE
Fix DeploymentValidator to allow multiple Deployments for cluster-api-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- In `DeploymentValidator`, when checking if the Deployment is unique, check `app.kubernetes.io/component` label if it is present.
+
 ## [0.6.2] - 2021-09-10
 
 ### Fixed


### PR DESCRIPTION
## What?

We want to deploy all three CAPI controllers from `cluster-api-app`.

Currently we check if the Deployment is unique by looking for deployments with same `app.kubernetes.io/name` and `app.kubernetes.io/version` labels. All three Deployments have same values for these labels, as they come from a single app repo, so the Deployment creation gets blocked.

## How?

This PR adds the check of `app.kubernetes.io/component` labels as well, if present only (so it's opt-in), so the Deployment is considered to be the same when all 3 mentioned labels have same values.

## Example

For the `cluster-api-app`, we would have these 3 Deployments:

- `capi-kubeadm-bootstrap-controller-manager`
  - `app.kubernetes.io/name: cluster-api`
  - `app.kubernetes.io/component: bootstrap-kubeadm`
  - `app.kubernetes.io/version: 0.3.0`
- `capi-kubeadm-control-plane-controller-manager`
  - `app.kubernetes.io/name: cluster-api`
  - `app.kubernetes.io/component: control-plane-kubeadm`
  - `app.kubernetes.io/version: 0.3.0`
- `capi-controller-manager`
  - `app.kubernetes.io/name: cluster-api`
  - `app.kubernetes.io/component: cluster-api`
  - `app.kubernetes.io/version: 0.3.0`

In this example the `app.kubernetes.io/component` matches the value of CAPI `cluster.x-k8s.io/provider` label and it is different in all three Deployments.