### PR TITLE
Exclude Crossplane from scrutiny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exclude `crossplane` which consists of many deployments.
+
 ## [0.7.0] - 2022-03-31
 
 ### Changed

--- a/config/default/webhook_selector_patch.yaml
+++ b/config/default/webhook_selector_patch.yaml
@@ -18,5 +18,6 @@ webhooks:
         - key: app.kubernetes.io/name
           operator: NotIn
           values:
+            - crossplane
             - flux-app
             - vertical-pod-autoscaler-app

--- a/helm/management-cluster-admission/templates/kustomize-out.yaml
+++ b/helm/management-cluster-admission/templates/kustomize-out.yaml
@@ -499,6 +499,7 @@ webhooks:
     - key: app.kubernetes.io/name
       operator: NotIn
       values:
+      - crossplane
       - flux-app
       - vertical-pod-autoscaler-app
   rules:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24830

Crossplane is being prevented from updating because it consists of more than one deployment.
```
~ kubectl get helmreleases -n flux-giantswarm
NAME             AGE     READY   STATUS
crossplane       2m47s   False   Helm rollback failed: cannot patch "crossplane" with kind Deployment: admission webhook "vdeployment.kb.io" denied the request: Found 2 deployments for selector = "app.kubernetes.io/component=cloud-infrastructure-controller,app.kubernetes.io/name=crossplane,app.kubernetes.io/version=1.9.1" and operation = "UPDATE", expected at most 1 && cannot patch "crossplane-rbac-manager" with kind Deployment: admission webhook "vdeployment.kb.io" denied the request: Found 2 deployments for selector = "app.kubernetes.io/component=cloud-infrastructure-controller,app.kubernetes.io/name=crossplane,app.kubernetes.io/version=1.9.1" and operation = "UPDATE", expected at most 1...
```

After adding this exception, it rolls out successfully:
```
~ flux resume helmrelease -n flux-giantswarm crossplane
► resuming helmrelease crossplane in flux-giantswarm namespace
✔ helmrelease resumed
◎ waiting for HelmRelease reconciliation
✔ HelmRelease reconciliation completed
✔ applied revision 0.3.1

~ kubectl get helmreleases -n flux-giantswarm
NAME             AGE   READY   STATUS
crossplane       13m   True    Release reconciliation succeeded
event-exporter   25h   True    Release reconciliation succeeded

~ kubectl get helmcharts -n flux-giantswarm
NAME                             CHART                         VERSION   SOURCE KIND      SOURCE NAME                              AGE   READY   STATUS
flux-giantswarm-crossplane       crossplane                    0.3.1     HelmRepository   giantswarmpublic-control-plane-catalog   13m   True    pulled 'crossplane' chart with version '0.3.1'
flux-giantswarm-event-exporter   caicloud-event-exporter-app   0.1.0     HelmRepository   giantswarmpublic-control-plane-catalog   25h   True    pulled 'caicloud-event-exporter-app' chart with version '0.1.0'

~ kubectl get deploy -n crossplane
NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
caicloud-event-exporter     1/1     1            1           25h
crossplane                  1/1     1            1           25h
crossplane-rbac-manager     1/1     1            1           25h
provider-aws-e0b33d016bb8   1/1     1            1           25h

~ kubectl get pods -n crossplane
NAME                                         READY   STATUS    RESTARTS   AGE
caicloud-event-exporter-76586698dd-6g8pz     1/1     Running   0          25h
crossplane-56d75dcdcb-g7qk6                  1/1     Running   0          25h
crossplane-rbac-manager-cc76d5654-bhs8f      1/1     Running   0          25h
provider-aws-e0b33d016bb8-7bcf4b5449-8q674   1/1     Running   0          25h
```
